### PR TITLE
Fix decryption for two games

### DIFF
--- a/cdecrypt.c
+++ b/cdecrypt.c
@@ -561,7 +561,8 @@ int main_utf8(int argc, char** argv)
                     fprintf(stderr, "ERROR: Could not open: '%s'\n", str);
                     goto out;
                 }
-                if ((getbe16(&fe[i].Flags) & 0x440)) {
+                uint16_t tmd_flags = tmd->Contents[getbe16(&fe[i].ContentID)].Type;
+                if ((getbe16(&tmd_flags) & 0x02)) {
                     if (!extract_file_hash(src, 0, cnt_offset, getbe32(&fe[i].FileLength), path, getbe16(&fe[i].ContentID)))
                         goto out;
                 } else {


### PR DESCRIPTION
This change is known to fix decryption of "Assassin's Creed III" and "Darts Up". This is a port of another PR: https://github.com/Xpl0itU/WiiUDownloader/pull/44

Previously, when attempting to decrypt either of these games with `cdecrypt`, decryption would fail and you'd get a message like this:
```
Size:019A1C0 Offset:0x0000000000 CID:0A U:400 code\WiiUNexPlugin.rpl
00000000  a2 cd 41 de 5c e2 8f 18 2c 60 1c e7 6f b0 3f 32  ..A.\...,`..o.?2
00000010  83 be ab a9                                      ....            

[hex dump separation for readability]

00000000  7f 45 4c 46 01 02 01 ca fe 00 00 00 00 00 00 00  .ELF............
00000010  fe 01 00 14 00 00 00 01 02 04 c0 c0 00 00 00 00  ................
00000020  00 00 00 40 00 00 00 00 00 34 00 00 00 00 00 28  ...@.....4.....(
00000030  00 1a 00 17 00 00 00 00 00 00 00 00 00 00 00 00  ................
00000040  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
00000050  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
00000060  00 00 00 00 00 00 00 00 00 00 00 01 00 00 00 01  ................
00000070  08 00 00 06 02 00 00 00 00 05 60 80 00 10 de 54  ..........`....T
00000080  00 00 00 00 00 00 00 00 00 00 00 20 00 00 00 00  ........... ....
00000090  00 00 00 07 80 00 00 01 08 00 00 06 c0 00 00 00  ................
000000a0  00 01 79 40 00 00 07 9c 00 00 00 00 00 00 00 00  ..y@............
000000b0  00 00 00 20 00 00 00 00 00 00 00 11 00 00 00 01  ... ............
000000c0  08 00 00 03 10 00 00 00 00 00 06 00 00 01 2a e9  ..............*.
000000d0  00 00 00 00 00 00 00 00 00 00 00 20 00 00 00 00  ........... ....
000000e0  00 00 00 19 00 00 00 01 08 00 00 03 10 04 f4 e0  ................
000000f0  00 01 31 00 00 00 47 c6 00 00 00 00 00 00 00 00  ..1...G.........

[hex dump separation for readability]

00000000  9f a7 93 02 ec 33 17 2a bd 80 a9 36 ad e0 60 b4  .....3.*...6..`.
00000010  00 00 04 50 00 00 00 68 00 00 00 00 00 00 00 00  ...P...h........
00000020  00 00 00 04 00 00 00 04 00 00 00 00 80 00 00 04  ................
00000030  00 00 00 00 00 00 00 00 00 00 04 c0 00 00 01 01  ................
00000040  00 00 00 00 00 00 00 00 00 00 00 04 00 00 00 00  ................
00000050  00 00 00 00 78 0e 81 c9 41 3a 97 46 05 0c c5 fe  ....x...A:.F....
00000060  a7 42 31 1e 07 f0 69 f3 00 00 00 00 25 4f 4c 5a  .B1...i.....%OLZ
00000070  1e 46 72 bd ee 96 b0 47 6f 62 f1 8f aa 53 b4 2a  .Fr....Gob...S.*
00000080  ea 77 86 f9 7b ac 1e 2e 06 2b a3 48 bb 89 79 22  .w..{....+.H..y"
00000090  73 bd 08 27 f6 ad ee 98 d0 43 b4 b1 42 23 e0 67  s..'.....C..B#.g
000000a0  14 59 6b 94 ad ec c3 fa c9 c0 21 42 40 86 06 77  .Yk.......!B@..w
000000b0  00 00 00 00 09 df 0d 1a 00 00 00 00 00 00 00 00  ................
000000c0  ca fe 04 02 00 2f 4c c0 00 00 00 20 00 0b d5 00  ...../L.... ....
000000d0  00 00 00 40 00 1b 61 a0 00 00 00 20 00 09 f3 60  ...@..a.... ...`
000000e0  00 00 00 00 00 00 80 00 00 00 80 00 00 01 00 00  ................
000000f0  00 00 00 60 00 00 00 00 00 00 80 00 00 00 00 a8  ...`............
ERROR: Could not verify H0 hash
```
Notice that the second hexdump contains an ELF header, as if the file was properly decrypted. However, the second hexdump is of `cdecrypt`'s array of verification hashes, not file content. I also noticed that [JNUSLib](https://github.com/Maschell/JNUSLib) works fine, and decrypts both games without issue.

The problem turned out to be in how `cdecrypt` decides whether the file contains hashes throughout or not. `cdecrypt` previously checked `fe[i].Flags & 0x440` for each entry, but apparently in the case of these two games, those bits don't correspond to whether the file is hashed or not. Apparently, JNUSLib decides based on the TMD file entry, which is still accurate in these cases. So, this PR changes `cdecrypt` to use the same method as JNUSLib for determining whether the file contains hashes or not.

I haven't tested this on a huge sample, but the games I have tested it on still work, and since JNUSLib uses it (apparently) successfully, it seems safe enough to me.